### PR TITLE
skip workspace root check

### DIFF
--- a/.github/workflows/snapit.yml
+++ b/.github/workflows/snapit.yml
@@ -94,7 +94,7 @@ jobs:
           git checkout origin/main -- .changeset
 
       - name: Install @changesets/changelog-github dependency
-        run: yarn add @changesets/changelog-github
+        run: yarn add --ignore-workspace-root-check @changesets/changelog-github
 
       - name: Generate Snapshot version
         id: generate-snapshot-version


### PR DESCRIPTION
```
Run yarn add @changesets/changelog-github
yarn add v1.22.21
error Running this command will add the dependency to the workspace root rather than the workspace itself, which might not be what you want - if you really meant it, make it explicit by running this command again with the -W flag (or --ignore-workspace-root-check).
info Visit https://yarnpkg.com/en/docs/cli/add for documentation about this command.
Error: Process completed with exit code 1.
```

https://classic.yarnpkg.com/en/docs/cli/add#toc-yarn-add-ignore-workspace-root-check-w